### PR TITLE
continuable.to should call function with consistent context.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -126,3 +126,18 @@ test("to:(AsyncFunction => MaybeContinuable)", function (assert) {
         })
     })
 })
+
+test("to preserves context", function (assert) {
+
+    var obj = {
+        foo: to(function (cb) {
+            cb(null, typeof this.foo)
+        })
+    }
+
+    obj.foo()(function (_, type) {
+      assert.equal(type, 'function')
+      assert.end()
+    })
+
+})

--- a/to.js
+++ b/to.js
@@ -6,6 +6,7 @@ function to(asyncFn) {
     return function () {
         var args = slice.call(arguments)
         var callback = args[args.length - 1]
+        var self = this
 
         if (typeof callback === "function") {
             return asyncFn.apply(this, args)
@@ -14,7 +15,7 @@ function to(asyncFn) {
         return function continuable(callback) {
             var _args = args.slice()
             _args.push(callback)
-            return asyncFn.apply(this, _args)
+            return asyncFn.apply(self, _args)
         }
     }
 }


### PR DESCRIPTION
`to` should remember the context of the object it was assigned to. Since maybe the function is returned, in which case it's probably called without a context. This change means that it is always called with a consistent context.
